### PR TITLE
Implement puzzle validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This project demonstrates a minimal puzzle framework with three game modes:
 Binary Rows, Binary Math and Grid Navigation. A small Flask app renders the
 puzzles in the browser.
 
+The Web UI includes a basic validation feature. Clicking **Check Solution**
+sends the current grid state to the server, which verifies it against the saved
+puzzle data.
+
 ## Running
 
 ```bash

--- a/planning.md
+++ b/planning.md
@@ -11,7 +11,7 @@ This document tracks high-level milestones and the status of each task derived f
  - [x] Design basic UI templates for each mode
  - [x] Implement game engine to route to selected mode
  - [x] Add save/load system for puzzles and player progress
- - [ ] Add simple puzzle validation (client-side and server-side)
+ - [x] Add simple puzzle validation (client-side and server-side)
 
 ## Milestone 2 – Trivia Expansion
 - [ ] Integrate OpenAI or Ollama API (configurable)

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,21 @@
+from verifier import verify_grid, verify_puzzle
+
+
+def test_verify_grid():
+    expected = [[1, 0], [0, 1]]
+    assert verify_grid(expected, [[1, 0], [0, 1]])
+    assert not verify_grid(expected, [[1, 1], [0, 1]])
+
+
+def test_verify_puzzle():
+    grid_puzzle = {"mode": "grid_navigation", "grid": [[1, 0], [0, 1]]}
+    assert verify_puzzle(grid_puzzle, {"grid": [[1, 0], [0, 1]]})
+    assert not verify_puzzle(grid_puzzle, {"grid": [[1, 1], [0, 1]]})
+
+    row_puzzle = {"mode": "binary_rows", "rows": ["10", "01"]}
+    assert verify_puzzle(row_puzzle, {"rows": ["10", "01"]})
+    assert not verify_puzzle(row_puzzle, {"rows": ["10", "10"]})
+
+    math_puzzle = {"mode": "binary_math", "pattern": "1010"}
+    assert verify_puzzle(math_puzzle, {"binary": "1010"})
+    assert not verify_puzzle(math_puzzle, {"binary": "1111"})

--- a/tests/test_web_validation.py
+++ b/tests/test_web_validation.py
@@ -1,0 +1,21 @@
+import json
+import os
+from webui.app import app
+
+
+def test_validate_solution_endpoint(tmp_path):
+    puzzle_path = tmp_path / "puzzle.json"
+    puzzle_data = {"mode": "grid_navigation", "grid": [[1, 0], [0, 1]]}
+    puzzle_path.write_text(json.dumps(puzzle_data))
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    res = client.post("/api/validate_solution", json={"grid": [[1, 0], [0, 1]]})
+    assert res.get_json()["status"] == "success"
+
+    res = client.post("/api/validate_solution", json={"grid": [[1, 1], [0, 1]]})
+    assert res.get_json()["status"] == "failure"
+    os.chdir(old_cwd)

--- a/tickets.md
+++ b/tickets.md
@@ -50,10 +50,10 @@
  - [x] Documentation Written
 
 ## T8 - Add simple puzzle validation (client-side and server-side)
- - [ ] Started
- - [ ] Tests Written
- - [ ] Code Written
- - [ ] Tests Passed
+ - [x] Started
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
  - [ ] Documentation Written
 
 ## T9 - Integrate OpenAI or Ollama API (configurable)

--- a/verifier.py
+++ b/verifier.py
@@ -1,1 +1,24 @@
-# Puzzle verification module
+"""Puzzle verification utilities."""
+from typing import Any, Dict, List
+
+
+def verify_grid(expected: List[List[int]], attempt: List[List[int]]) -> bool:
+    """Return True if two grids are identical."""
+    if len(expected) != len(attempt):
+        return False
+    for row_exp, row_att in zip(expected, attempt):
+        if row_exp != row_att:
+            return False
+    return True
+
+
+def verify_puzzle(puzzle: Dict[str, Any], attempt: Dict[str, Any]) -> bool:
+    """Validate a puzzle attempt based on puzzle metadata."""
+    mode = puzzle.get("mode")
+    if mode == "grid_navigation":
+        return verify_grid(puzzle.get("grid", []), attempt.get("grid", []))
+    if mode == "binary_rows":
+        return puzzle.get("rows") == attempt.get("rows")
+    if mode == "binary_math":
+        return puzzle.get("pattern") == attempt.get("binary")
+    return False

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,6 +1,7 @@
 """Minimal Flask app for QR Puzzle Generator."""
-from flask import Flask, render_template, jsonify
+from flask import Flask, render_template, jsonify, request
 from puzzle_generator import PuzzleGenerator
+from verifier import verify_puzzle
 
 app = Flask(__name__)
 
@@ -24,6 +25,18 @@ def load_solution():
         return jsonify({'status': 'success', **data})
     except FileNotFoundError:
         return jsonify({'status': 'error', 'message': 'no puzzle'}), 404
+
+
+@app.route('/api/validate_solution', methods=['POST'])
+def validate_solution():
+    """Validate a posted puzzle solution."""
+    try:
+        puzzle = PuzzleGenerator().load('puzzle.json')
+    except FileNotFoundError:
+        return jsonify({'status': 'error', 'message': 'no puzzle'}), 404
+    attempt = request.get_json(silent=True) or {}
+    success = verify_puzzle(puzzle, attempt)
+    return jsonify({'status': 'success' if success else 'failure'})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/webui/templates/game.html
+++ b/webui/templates/game.html
@@ -46,16 +46,14 @@
             drawGrid();
         });
 
-        function checkSolution() {
-            let correct = true;
-            for (let i = 0; i < gridSize; i++) {
-                for (let j = 0; j < gridSize; j++) {
-                    if (playerGrid[i][j] !== solution[i][j]) {
-                        correct = false;
-                    }
-                }
-            }
-            document.getElementById("result").innerText = correct
+        async function checkSolution() {
+            const res = await fetch("/api/validate_solution", {
+                method: "POST",
+                headers: {"Content-Type": "application/json"},
+                body: JSON.stringify({grid: playerGrid})
+            });
+            const data = await res.json();
+            document.getElementById("result").innerText = data.status === "success"
                 ? "✅ Correct! Well done."
                 : "❌ Not quite. Try again!";
         }


### PR DESCRIPTION
## Summary
- add puzzle validation utilities
- enable server-side validation route in Flask app
- post solution from UI via new endpoint
- document validation capability
- add tests for validator and web endpoint
- mark milestone and ticket progress

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876672e250483328e551ced31b5069c