### PR TITLE
Implement trivia generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ puzzles in the browser.
 
 The Web UI includes a basic validation feature. Clicking **Check Solution**
 sends the current grid state to the server, which verifies it against the saved
-puzzle data.
+puzzle data.  
+Milestone 2 introduces a trivia generator used to reveal parts of a puzzle.
 
 ## Running
 
@@ -16,3 +17,9 @@ python3 main.py
 # Launch the web UI
 python3 webui/app.py
 ```
+
+## Trivia Generation
+
+`TriviaGenerator` can create questions using OpenAI or Ollama depending on the
+`TRIVIA_PROVIDER` environment variable. When neither provider is configured it
+falls back to a dummy implementation which is used in tests.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .trivia_generator import TriviaGenerator

--- a/planning.md
+++ b/planning.md
@@ -14,12 +14,12 @@ This document tracks high-level milestones and the status of each task derived f
  - [x] Add simple puzzle validation (client-side and server-side)
 
 ## Milestone 2 – Trivia Expansion
-- [ ] Integrate OpenAI or Ollama API (configurable)
-- [ ] Create `trivia_generator.py` to handle clue → prompt → question
-- [ ] Generate trivia from puzzle rules (e.g. “Reveal row 3”)
-- [ ] Store correct answers and map to puzzle actions
-- [ ] UI form for trivia questions and answer handling
-- [ ] Add scoring or unlock mechanic based on trivia
+- [x] Integrate OpenAI or Ollama API (configurable)
+- [x] Create `trivia_generator.py` to handle clue → prompt → question
+- [x] Generate trivia from puzzle rules (e.g. “Reveal row 3”)
+ - [ ] Store correct answers and map to puzzle actions
+ - [ ] UI form for trivia questions and answer handling
+ - [ ] Add scoring or unlock mechanic based on trivia
 
 ## Milestone 3 – Intermediate Game Modes
 - [ ] Add **Logic Constraints** puzzle type

--- a/tests/test_trivia_generator.py
+++ b/tests/test_trivia_generator.py
@@ -1,0 +1,39 @@
+import builtins
+import types
+
+import json
+
+from trivia_generator import TriviaGenerator
+
+
+def test_dummy_provider():
+    tg = TriviaGenerator(provider="dummy")
+    q = tg.generate_question("science")
+    assert q["question"].startswith("Dummy question")
+    assert q["answer"] == "42"
+
+
+def test_openai_provider(monkeypatch):
+    fake_response = types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=json.dumps({"question": "Q?", "answer": "A"})) )])
+
+    class FakeCompletion:
+        @staticmethod
+        def create(model, messages, temperature):
+            return fake_response
+
+    fake_openai = types.SimpleNamespace(ChatCompletion=FakeCompletion)
+    import trivia_generator as tg_mod
+    monkeypatch.setattr(tg_mod, 'openai', fake_openai)
+
+    tg = TriviaGenerator(provider="openai")
+    tg.openai_key = "test"
+    q = tg.generate_question("history")
+    assert q == {"question": "Q?", "answer": "A"}
+
+
+def test_generate_from_rule():
+    tg = TriviaGenerator(provider="dummy")
+    q = tg.generate_from_rule("Reveal row 3")
+    assert "row 3" in q["question"]
+
+

--- a/tickets.md
+++ b/tickets.md
@@ -57,24 +57,24 @@
  - [ ] Documentation Written
 
 ## T9 - Integrate OpenAI or Ollama API (configurable)
- - [ ] Started
- - [ ] Tests Written
- - [ ] Code Written
- - [ ] Tests Passed
- - [ ] Documentation Written
+ - [x] Started
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
+ - [x] Documentation Written
 
 ## T10 - Create `trivia_generator.py` for trivia question handling
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 ## T11 - Generate trivia from puzzle rules
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
 - [ ] Documentation Written
 
 ## T12 - Store correct trivia answers and map to puzzle actions

--- a/trivia_generator.py
+++ b/trivia_generator.py
@@ -1,0 +1,72 @@
+"""Trivia question generation module with LLM integration."""
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+try:
+    import openai  # type: ignore
+except ImportError:  # pragma: no cover - openai optional
+    openai = None  # type: ignore
+
+import json
+import requests
+
+
+class TriviaGenerator:
+    """Generate trivia questions using different providers."""
+
+    def __init__(self, provider: Optional[str] = None):
+        self.provider = (provider or os.getenv("TRIVIA_PROVIDER", "dummy")).lower()
+        self.openai_key = os.getenv("OPENAI_API_KEY")
+        self.ollama_url = os.getenv("OLLAMA_URL", "http://localhost:11434/api/generate")
+
+    def generate_question(self, clue: str) -> Dict[str, str]:
+        """Return a trivia question and answer for a given clue."""
+        if self.provider == "openai":
+            return self._generate_openai(clue)
+        if self.provider == "ollama":
+            return self._generate_ollama(clue)
+        return self._generate_dummy(clue)
+
+    def _generate_openai(self, clue: str) -> Dict[str, str]:
+        if openai is None:
+            raise RuntimeError("openai package not installed")
+        if not self.openai_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        openai.api_key = self.openai_key
+        prompt = f"Create one trivia question about {clue}. Return JSON with 'question' and 'answer'."
+        res = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+        text = res.choices[0].message.content
+        try:
+            data = json.loads(text)
+            return {"question": data.get("question", ""), "answer": data.get("answer", "")}
+        except json.JSONDecodeError:
+            # Fallback if response not JSON
+            return {"question": text.strip(), "answer": ""}
+
+    def _generate_ollama(self, clue: str) -> Dict[str, str]:
+        payload = {
+            "model": "llama3",
+            "prompt": f"Create one trivia question about {clue}. Return JSON with 'question' and 'answer'.",
+            "stream": False,
+        }
+        res = requests.post(self.ollama_url, json=payload, timeout=10)
+        res.raise_for_status()
+        text = res.json().get("response", "{}").strip()
+        try:
+            data = json.loads(text)
+            return {"question": data.get("question", ""), "answer": data.get("answer", "")}
+        except json.JSONDecodeError:
+            return {"question": text, "answer": ""}
+
+    def _generate_dummy(self, clue: str) -> Dict[str, str]:
+        return {"question": f"Dummy question about {clue}?", "answer": "42"}
+
+    def generate_from_rule(self, rule: str) -> Dict[str, str]:
+        """Convenience wrapper to generate trivia from a puzzle rule."""
+        return self.generate_question(rule)


### PR DESCRIPTION
## Summary
- add a `TriviaGenerator` module with OpenAI/Ollama integration
- document the trivia system and update planning
- mark tickets T9-T11 as in-progress or done
- add unit tests for the new trivia module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687669add00c8332a955cbb6eae867a4