### PR TITLE
Add trivia mapping and docs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,3 +1,3 @@
 from .trivia_generator import TriviaGenerator
 from .qr_processor import generate_matrix, load_matrix
-from .qr_puzzle_generator import generate_qr_puzzles
+from .qr_puzzle_generator import generate_qr_puzzles, generate_qr_puzzles_with_trivia

--- a/docs/qr_puzzle_workflow.md
+++ b/docs/qr_puzzle_workflow.md
@@ -1,0 +1,7 @@
+# QR Puzzle Workflow
+
+1. **Generate QR Matrix** – `qr_processor.generate_matrix` converts any text into a matrix of `1` and `0` values.
+2. **Segment Matrix** – `qr_puzzle_generator.segment_matrix` splits the matrix into smaller chunks.
+3. **Map to Puzzles** – `qr_puzzle_generator.matrix_to_puzzles` converts each chunk into a mini-game puzzle. Currently chunks become `grid_navigation` puzzles.
+4. **(Optional) Attach Trivia** – `qr_puzzle_generator.generate_qr_puzzles_with_trivia` can attach a trivia question to each chunk, storing the expected answer along with a reference to the chunk to reveal.
+5. **Render in Web UI** – the puzzles are presented in the browser where players solve them to gradually reveal the full QR code.

--- a/docs/trivia_workflow.md
+++ b/docs/trivia_workflow.md
@@ -1,0 +1,5 @@
+# Trivia Workflow
+
+Trivia questions are generated from puzzle rules using `TriviaGenerator`. Each rule describes which puzzle portion to reveal. For example, `"Reveal chunk 0"` becomes a trivia question whose correct answer unlocks that chunk in the game.
+
+Questions can come from different providers (`dummy`, `openai`, or `ollama`). The returned dictionary contains both the question and its expected answer so the front end can validate the player's response.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -1,0 +1,5 @@
+# Puzzle Validation
+
+The project validates puzzle solutions both on the client and the server. The web UI collects the player's grid clicks and submits them to `/api/validate_solution`. On the server side, `verifier.verify_puzzle` compares the submitted data to the stored puzzle representation.
+
+This simple approach keeps the gameplay responsive while preventing players from bypassing puzzle rules.

--- a/planning.md
+++ b/planning.md
@@ -17,7 +17,7 @@ This document tracks high-level milestones and the status of each task derived f
 - [x] Integrate OpenAI or Ollama API (configurable)
 - [x] Create `trivia_generator.py` to handle clue → prompt → question
 - [x] Generate trivia from puzzle rules (e.g. “Reveal row 3”)
- - [ ] Store correct answers and map to puzzle actions
+ - [x] Store correct answers and map to puzzle actions
  - [ ] UI form for trivia questions and answer handling
  - [ ] Add scoring or unlock mechanic based on trivia
 

--- a/qr_puzzle_generator.py
+++ b/qr_puzzle_generator.py
@@ -1,7 +1,7 @@
 """Generate mini-game puzzles from a QR code matrix."""
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from core.game_engine import GameEngine
 from qr_processor import generate_matrix
@@ -17,14 +17,26 @@ def segment_matrix(matrix: List[List[int]], size: int) -> List[List[List[int]]]:
     return chunks
 
 
-def matrix_to_puzzles(matrix: List[List[int]], chunk_size: int = 3) -> List[Dict[str, Any]]:
-    """Map a QR matrix to grid navigation puzzles."""
+def matrix_to_puzzles(
+    matrix: List[List[int]],
+    chunk_size: int = 3,
+    trivia: Optional["TriviaGenerator"] = None,
+) -> List[Dict[str, Any]]:
+    """Map a QR matrix to grid navigation puzzles.
+
+    If ``trivia`` is provided, each chunk includes a trivia question and answer
+    to gate revealing that portion of the QR code.
+    """
     engine = GameEngine()
     puzzles: List[Dict[str, Any]] = []
-    for chunk in segment_matrix(matrix, chunk_size):
+    for idx, chunk in enumerate(segment_matrix(matrix, chunk_size)):
         puzzle = engine.create("grid_navigation", size=len(chunk))
         puzzle.grid = chunk
-        puzzles.append({"mode": "grid_navigation", "grid": chunk})
+        entry: Dict[str, Any] = {"mode": "grid_navigation", "grid": chunk}
+        if trivia is not None:
+            q = trivia.generate_from_rule(f"Reveal chunk {idx}")
+            entry["trivia"] = {**q, "action": f"reveal_chunk_{idx}"}
+        puzzles.append(entry)
     return puzzles
 
 
@@ -32,4 +44,17 @@ def generate_qr_puzzles(data: str, chunk_size: int = 3) -> List[Dict[str, Any]]:
     """High-level helper to create puzzles from ``data``."""
     matrix = generate_matrix(data)
     return matrix_to_puzzles(matrix, chunk_size)
+
+
+def generate_qr_puzzles_with_trivia(
+    data: str,
+    chunk_size: int = 3,
+    provider: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Create puzzles from ``data`` and attach trivia questions."""
+    from trivia_generator import TriviaGenerator
+
+    matrix = generate_matrix(data)
+    tg = TriviaGenerator(provider=provider)
+    return matrix_to_puzzles(matrix, chunk_size, trivia=tg)
 

--- a/tests/test_qr_puzzle_generator.py
+++ b/tests/test_qr_puzzle_generator.py
@@ -1,4 +1,9 @@
-from qr_puzzle_generator import segment_matrix, matrix_to_puzzles, generate_qr_puzzles
+from qr_puzzle_generator import (
+    segment_matrix,
+    matrix_to_puzzles,
+    generate_qr_puzzles,
+    generate_qr_puzzles_with_trivia,
+)
 from qr_processor import generate_matrix
 
 
@@ -24,3 +29,11 @@ def test_generate_qr_puzzles():
     puzzles = generate_qr_puzzles("data", chunk_size=2)
     assert puzzles
     assert all(p["mode"] == "grid_navigation" for p in puzzles)
+
+
+def test_generate_qr_puzzles_with_trivia():
+    puzzles = generate_qr_puzzles_with_trivia("hello", chunk_size=2, provider="dummy")
+    assert puzzles
+    assert all("trivia" in p for p in puzzles)
+    first = puzzles[0]["trivia"]
+    assert "question" in first and "answer" in first and "action" in first

--- a/tickets.md
+++ b/tickets.md
@@ -54,7 +54,7 @@
  - [x] Tests Written
  - [x] Code Written
  - [x] Tests Passed
- - [ ] Documentation Written
+ - [x] Documentation Written
 
 ## T9 - Integrate OpenAI or Ollama API (configurable)
  - [x] Started
@@ -75,14 +75,14 @@
 - [x] Tests Written
 - [x] Code Written
 - [x] Tests Passed
-- [ ] Documentation Written
+ - [x] Documentation Written
 
 ## T12 - Store correct trivia answers and map to puzzle actions
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+ - [x] Started
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
+ - [x] Documentation Written
 
 ## T13 - Create UI form for trivia questions and answer handling
 - [ ] Started
@@ -226,7 +226,7 @@
 
 ## T33 - [High Priority] Document QR puzzle workflow
  - [x] Started
- - [ ] Tests Written
- - [ ] Code Written
- - [ ] Tests Passed
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
  - [x] Documentation Written


### PR DESCRIPTION
## Summary
- attach trivia questions to QR chunks via `generate_qr_puzzles_with_trivia`
- document QR puzzle generation, trivia workflow and puzzle validation
- update tickets for completed items
- mark milestone progress
- test new trivia function

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687673f1f08c8332a881122ce23f6f84