### PR TITLE
Add trivia UI and scoring

### DIFF
--- a/docs/trivia_workflow.md
+++ b/docs/trivia_workflow.md
@@ -3,3 +3,5 @@
 Trivia questions are generated from puzzle rules using `TriviaGenerator`. Each rule describes which puzzle portion to reveal. For example, `"Reveal chunk 0"` becomes a trivia question whose correct answer unlocks that chunk in the game.
 
 Questions can come from different providers (`dummy`, `openai`, or `ollama`). The returned dictionary contains both the question and its expected answer so the front end can validate the player's response.
+
+The Web UI now exposes `/trivia` which fetches a question from `/api/trivia_question` and submits an answer to `/api/trivia_answer`. Correct answers increment an in-memory score returned by the API.

--- a/planning.md
+++ b/planning.md
@@ -18,8 +18,8 @@ This document tracks high-level milestones and the status of each task derived f
 - [x] Create `trivia_generator.py` to handle clue → prompt → question
 - [x] Generate trivia from puzzle rules (e.g. “Reveal row 3”)
  - [x] Store correct answers and map to puzzle actions
- - [ ] UI form for trivia questions and answer handling
- - [ ] Add scoring or unlock mechanic based on trivia
+ - [x] UI form for trivia questions and answer handling
+ - [x] Add scoring or unlock mechanic based on trivia
 
 ## Milestone 2.5 – QR Code Puzzle Algorithm (High Priority)
 - [x] Generate or load a QR code and extract its matrix

--- a/tests/test_trivia_ui.py
+++ b/tests/test_trivia_ui.py
@@ -1,0 +1,34 @@
+import json
+import os
+from webui.app import app, TRIVIA_SCORE
+
+
+def test_trivia_endpoints(tmp_path):
+    puzzle_path = tmp_path / "puzzle.json"
+    puzzle_data = {
+        "mode": "grid_navigation",
+        "grid": [[1, 0], [0, 1]],
+        "trivia": {"question": "Q?", "answer": "A", "action": "reveal"}
+    }
+    puzzle_path.write_text(json.dumps(puzzle_data))
+
+    old_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    app.config["TESTING"] = True
+    client = app.test_client()
+
+    res = client.get("/api/trivia_question")
+    assert res.status_code == 200
+    assert res.get_json()["question"] == "Q?"
+
+    res = client.post("/api/trivia_answer", json={"answer": "A"})
+    data = res.get_json()
+    assert data["status"] == "correct"
+    first_score = data["score"]
+
+    res = client.post("/api/trivia_answer", json={"answer": "wrong"})
+    data = res.get_json()
+    assert data["status"] == "incorrect"
+    assert data["score"] == first_score
+
+    os.chdir(old_cwd)

--- a/tickets.md
+++ b/tickets.md
@@ -85,18 +85,18 @@
  - [x] Documentation Written
 
 ## T13 - Create UI form for trivia questions and answer handling
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 ## T14 - Add scoring or unlock mechanic based on trivia
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+- [x] Started
+- [x] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [x] Documentation Written
 
 ## T15 - Add Logic Constraints puzzle type
 - [ ] Started

--- a/webui/app.py
+++ b/webui/app.py
@@ -3,6 +3,9 @@ from flask import Flask, render_template, jsonify, request
 from puzzle_generator import PuzzleGenerator
 from verifier import verify_puzzle
 
+# simple in-memory score for trivia questions
+TRIVIA_SCORE = 0
+
 app = Flask(__name__)
 
 @app.route('/')
@@ -18,6 +21,12 @@ def game(mode):
     }.get(mode, 'index.html')
     return render_template(template)
 
+
+@app.route('/trivia')
+def trivia_page():
+    """Render the trivia question page."""
+    return render_template('trivia.html')
+
 @app.route('/api/load_solution')
 def load_solution():
     try:
@@ -25,6 +34,21 @@ def load_solution():
         return jsonify({'status': 'success', **data})
     except FileNotFoundError:
         return jsonify({'status': 'error', 'message': 'no puzzle'}), 404
+
+
+@app.route('/api/trivia_question')
+def trivia_question():
+    """Return the stored trivia question if available."""
+    try:
+        puzzle = PuzzleGenerator().load('puzzle.json')
+    except FileNotFoundError:
+        return jsonify({'status': 'error', 'message': 'no puzzle'}), 404
+    trivia = puzzle.get('trivia')
+    if isinstance(trivia, list):
+        trivia = trivia[0] if trivia else None
+    if not trivia:
+        return jsonify({'status': 'error', 'message': 'no trivia'}), 404
+    return jsonify({'status': 'success', 'question': trivia.get('question', '')})
 
 
 @app.route('/api/validate_solution', methods=['POST'])
@@ -37,6 +61,24 @@ def validate_solution():
     attempt = request.get_json(silent=True) or {}
     success = verify_puzzle(puzzle, attempt)
     return jsonify({'status': 'success' if success else 'failure'})
+
+
+@app.route('/api/trivia_answer', methods=['POST'])
+def trivia_answer():
+    """Validate a trivia answer and update score."""
+    global TRIVIA_SCORE
+    try:
+        puzzle = PuzzleGenerator().load('puzzle.json')
+    except FileNotFoundError:
+        return jsonify({'status': 'error', 'message': 'no puzzle'}), 404
+    trivia = puzzle.get('trivia', {})
+    expected = str(trivia.get('answer', '')).strip().lower()
+    data = request.get_json(silent=True) or {}
+    answer = str(data.get('answer', '')).strip().lower()
+    if answer == expected and expected:
+        TRIVIA_SCORE += 1
+        return jsonify({'status': 'correct', 'score': TRIVIA_SCORE})
+    return jsonify({'status': 'incorrect', 'score': TRIVIA_SCORE})
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/webui/templates/trivia.html
+++ b/webui/templates/trivia.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Trivia Challenge</title>
+</head>
+<body>
+    <h1>Trivia Question</h1>
+    <p id="question">Loading...</p>
+    <form id="answerForm">
+        <input type="text" id="answerInput" />
+        <button type="submit">Submit</button>
+    </form>
+    <p id="result"></p>
+    <a href="/">Back</a>
+    <script>
+        async function loadQuestion() {
+            const res = await fetch('/api/trivia_question');
+            const data = await res.json();
+            if (data.status === 'success') {
+                document.getElementById('question').innerText = data.question;
+            } else {
+                document.getElementById('question').innerText = 'No trivia available.';
+            }
+        }
+
+        document.getElementById('answerForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const answer = document.getElementById('answerInput').value;
+            const res = await fetch('/api/trivia_answer', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ answer })
+            });
+            const data = await res.json();
+            const msg = data.status === 'correct' ? 'Correct!' : 'Incorrect.';
+            document.getElementById('result').innerText = msg + ' Score: ' + data.score;
+        });
+
+        loadQuestion();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add trivia web interface and API endpoints
- implement simple scoring logic for trivia answers
- document trivia UI workflow and update plans
- add tests for trivia endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876818b4d3883329ddcb6e822374030