### PR TITLE
Implement logic constraint and modular rule puzzles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # QR Puzzle Generator - MVP
 
-This project demonstrates a minimal puzzle framework with three game modes:
-Binary Rows, Binary Math and Grid Navigation. A small Flask app renders the
-puzzles in the browser.
+This project demonstrates a modular puzzle framework. Initial game modes include
+Binary Rows, Binary Math and Grid Navigation. Milestone 3 adds Logic
+Constraints and Modular Math Rules. A small Flask app renders the puzzles in the
+browser.
 
 The Web UI includes a basic validation feature. Clicking **Check Solution**
 sends the current grid state to the server, which verifies it against the saved

--- a/core/game_engine.py
+++ b/core/game_engine.py
@@ -4,6 +4,8 @@ from typing import Any, Dict
 from .binary_rows import BinaryRows
 from .binary_math import BinaryMath
 from .grid_navigation import GridNavigation
+from .logic_constraints import LogicConstraints
+from .modular_rules import ModularRules
 
 class GameEngine:
     """Factory-like interface to create puzzle instances."""
@@ -14,5 +16,13 @@ class GameEngine:
         if mode == "binary_math":
             return BinaryMath(kwargs.get("question", ""), kwargs.get("answer", 0))
         if mode == "grid_navigation":
-            return GridNavigation(kwargs.get("size", 5), kwargs.get("start", (0,0)))
+            return GridNavigation(kwargs.get("size", 5), kwargs.get("start", (0, 0)))
+        if mode == "logic_constraints":
+            return LogicConstraints(kwargs.get("grid", []))
+        if mode == "modular_rules":
+            return ModularRules(
+                kwargs.get("size", 5),
+                kwargs.get("mod", 2),
+                kwargs.get("remainder", 0),
+            )
         raise ValueError(f"Unknown game mode: {mode}")

--- a/core/logic_constraints.py
+++ b/core/logic_constraints.py
@@ -1,0 +1,50 @@
+"""Logic Constraints puzzle type (Picross-style)."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+class LogicConstraints:
+    """Represents a puzzle defined by row and column hints."""
+
+    def __init__(self, grid: List[List[int]]):
+        self.grid = grid
+        self.row_hints = [self._compute_hints(row) for row in grid]
+        self.col_hints = [
+            self._compute_hints([grid[r][c] for r in range(len(grid))])
+            for c in range(len(grid[0]))
+        ] if grid else []
+
+    @staticmethod
+    def _compute_hints(line: List[int]) -> List[int]:
+        hints: List[int] = []
+        count = 0
+        for cell in line:
+            if cell:
+                count += 1
+            else:
+                if count > 0:
+                    hints.append(count)
+                    count = 0
+        if count > 0:
+            hints.append(count)
+        if not hints:
+            hints.append(0)
+        return hints
+
+    def expected_hints(self) -> Dict[str, List[List[int]]]:
+        """Return row and column hints."""
+        return {"rows": self.row_hints, "cols": self.col_hints}
+
+    def check_solution(self, player_grid: List[List[int]]) -> bool:
+        """Validate a player's solution against expected hints."""
+        if not player_grid or not self.grid:
+            return False
+        if len(player_grid) != len(self.grid) or len(player_grid[0]) != len(self.grid[0]):
+            return False
+        row_hints = [self._compute_hints(row) for row in player_grid]
+        col_hints = [
+            self._compute_hints([player_grid[r][c] for r in range(len(player_grid))])
+            for c in range(len(player_grid[0]))
+        ]
+        return row_hints == self.row_hints and col_hints == self.col_hints

--- a/core/modular_rules.py
+++ b/core/modular_rules.py
@@ -1,0 +1,25 @@
+"""Modular Math Rules puzzle type."""
+from __future__ import annotations
+
+from typing import List
+
+
+class ModularRules:
+    """Puzzle where black squares satisfy a modular rule."""
+
+    def __init__(self, size: int, mod: int, remainder: int = 0):
+        self.size = size
+        self.mod = mod
+        self.remainder = remainder
+        self.grid = [
+            [1 if (r + c) % mod == remainder else 0 for c in range(size)]
+            for r in range(size)
+        ]
+
+    def expected_grid(self) -> List[List[int]]:
+        """Return the generated grid."""
+        return self.grid
+
+    def check_solution(self, player_grid: List[List[int]]) -> bool:
+        """Validate that ``player_grid`` matches the generated pattern."""
+        return player_grid == self.grid

--- a/docs/logic_constraints.md
+++ b/docs/logic_constraints.md
@@ -1,0 +1,5 @@
+# Logic Constraints Puzzle
+
+This puzzle type uses Picross-style hints derived from a binary grid.
+Row and column hints specify groups of consecutive black squares.
+Players fill the grid so that their hints match the expected hints.

--- a/docs/modular_rules.md
+++ b/docs/modular_rules.md
@@ -1,0 +1,4 @@
+# Modular Math Rules Puzzle
+
+Cells are colored black when `(row + column) % mod == remainder` for the configured values.
+The puzzle generates the expected grid automatically and validates a player's grid against this pattern.

--- a/planning.md
+++ b/planning.md
@@ -30,8 +30,8 @@ This document tracks high-level milestones and the status of each task derived f
 - [x] Document algorithm usage
 
 ## Milestone 3 – Intermediate Game Modes
-- [ ] Add **Logic Constraints** puzzle type
-- [ ] Add **Modular Math Rules** puzzle type
+- [x] Add **Logic Constraints** puzzle type
+- [x] Add **Modular Math Rules** puzzle type
 - [ ] Improve grid rendering with helper visuals (row hints, highlights)
 - [ ] Add visual feedback for incorrect moves or conflicting logic
 

--- a/tests/test_logic_constraints.py
+++ b/tests/test_logic_constraints.py
@@ -1,0 +1,15 @@
+from core.logic_constraints import LogicConstraints
+
+
+def test_logic_constraints():
+    grid = [
+        [1, 0, 1],
+        [1, 1, 0],
+        [0, 1, 1],
+    ]
+    puzzle = LogicConstraints(grid)
+    hints = puzzle.expected_hints()
+    assert hints["rows"] == [[1, 1], [2], [2]]
+    assert hints["cols"] == [[2], [2], [1, 1]]
+    assert puzzle.check_solution(grid)
+    assert not puzzle.check_solution([[0, 0, 0], [0, 0, 0], [0, 0, 0]])

--- a/tests/test_modular_rules.py
+++ b/tests/test_modular_rules.py
@@ -1,0 +1,13 @@
+from core.modular_rules import ModularRules
+
+
+def test_modular_rules():
+    puzzle = ModularRules(size=3, mod=2, remainder=0)
+    expected = [
+        [1, 0, 1],
+        [0, 1, 0],
+        [1, 0, 1],
+    ]
+    assert puzzle.expected_grid() == expected
+    assert puzzle.check_solution(expected)
+    assert not puzzle.check_solution([[0] * 3 for _ in range(3)])

--- a/tests/test_webui_routes.py
+++ b/tests/test_webui_routes.py
@@ -1,0 +1,9 @@
+from webui.app import app
+
+
+def test_basic_routes():
+    app.config["TESTING"] = True
+    client = app.test_client()
+    assert client.get("/").status_code == 200
+    assert client.get("/game/binary_rows").status_code == 200
+    assert client.get("/trivia").status_code == 200

--- a/tickets.md
+++ b/tickets.md
@@ -23,16 +23,16 @@
 
 ## T4 - Build minimal Flask Web UI
  - [x] Started
- - [ ] Tests Written
+ - [x] Tests Written
  - [x] Code Written
- - [ ] Tests Passed
+ - [x] Tests Passed
  - [x] Documentation Written
 
 ## T5 - Design basic UI templates for each mode
  - [x] Started
- - [ ] Tests Written
+ - [x] Tests Written
  - [x] Code Written
- - [ ] Tests Passed
+ - [x] Tests Passed
  - [x] Documentation Written
 
 ## T6 - Implement game engine to route to selected mode
@@ -99,18 +99,18 @@
 - [x] Documentation Written
 
 ## T15 - Add Logic Constraints puzzle type
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+ - [x] Started
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
+ - [x] Documentation Written
 
 ## T16 - Add Modular Math Rules puzzle type
-- [ ] Started
-- [ ] Tests Written
-- [ ] Code Written
-- [ ] Tests Passed
-- [ ] Documentation Written
+ - [x] Started
+ - [x] Tests Written
+ - [x] Code Written
+ - [x] Tests Passed
+ - [x] Documentation Written
 
 ## T17 - Improve grid rendering with helper visuals
 - [ ] Started


### PR DESCRIPTION
## Summary
- add LogicConstraints puzzle type with row/column hints
- add ModularRules puzzle type for modular math grids
- expose new puzzles through GameEngine
- add docs and README updates
- write tests for new puzzles and web UI routes
- mark planning and ticket progress

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687689ff9bc08332b3ce79ce825815bc